### PR TITLE
Fix env var override

### DIFF
--- a/src/teststack/commands/containers.py
+++ b/src/teststack/commands/containers.py
@@ -17,7 +17,7 @@ the tests you could do the following.
 
     teststack build --rebuild run
 """
-import os.path
+import os
 import sys
 
 import click
@@ -190,11 +190,11 @@ def render(ctx, template_file, dockerfile):
             ]
         ),
     )
-    template.stream(
-        GIT_BRANCH=ctx.obj.get('branch', 'dev'),
-        GIT_COMMIT_HASH=ctx.obj.get('commit', None),
+    template.stream(**{
+        'GIT_BRANCH': ctx.obj.get('branch', 'dev'),
+        'GIT_COMMIT_HASH': ctx.obj.get('commit', None),
         **os.environ,
-    ).dump(dockerfile)
+    }).dump(dockerfile)
 
 
 @cli.command()

--- a/src/teststack/commands/containers.py
+++ b/src/teststack/commands/containers.py
@@ -190,11 +190,13 @@ def render(ctx, template_file, dockerfile):
             ]
         ),
     )
-    template.stream(**{
-        'GIT_BRANCH': ctx.obj.get('branch', 'dev'),
-        'GIT_COMMIT_HASH': ctx.obj.get('commit', None),
-        **os.environ,
-    }).dump(dockerfile)
+    template.stream(
+        **{
+            'GIT_BRANCH': ctx.obj.get('branch', 'dev'),
+            'GIT_COMMIT_HASH': ctx.obj.get('commit', None),
+            **os.environ,
+        }
+    ).dump(dockerfile)
 
 
 @cli.command()

--- a/tests/unit/test_command_containers.py
+++ b/tests/unit/test_command_containers.py
@@ -1,4 +1,4 @@
-import pathlib
+import os
 import tempfile
 from unittest import mock
 
@@ -19,6 +19,13 @@ def test_render(runner, tag):
             assert fh_.readline() == '\n'
             assert 'docker-metadata' in fh_.readline()
             assert tag['commit'] in fh_.readline()
+
+
+def test_render_with_env_var_override(runner):
+    with tempfile.NamedTemporaryFile() as tmpfile:
+        with mock.patch.dict(os.environ, {'GIT_BRANCH': 'other'}):
+            result = runner.invoke(cli, ['render', f'--dockerfile={tmpfile.name}'])
+            assert result.exit_code == 0
 
 
 def test_render_isolated(runner):


### PR DESCRIPTION
I think the intent was to provide a default for `GIT_BRANCH` that can be overridden with env vars. This is broken and  causes the `render` command to fail with `TypeError: jinja2.environment.Template.stream() got multiple values for keyword argument 'GIT_BRANCH'` if `GIT_BRANCH` env var is defined. Confusingly it seems that `**kwargs` can't override the explicitly provided parameters in a function call but they _can_ override in a dict construction.