### PR TITLE
include a local config file

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -5,9 +5,9 @@ Configuration
 The ``teststack.toml`` config file is located in each projects root directory,
 preferably managed by git.
 
-This file is managed by toml, so the end result is a dictionary, and you can
-represent the options however you like as long as they result in the same
-dictionary structure.
+There is also a ``teststack.local.toml`` file that can be configured so that
+users can overwrite stuff in the teststack.toml file without modifying it. This
+file should be included in the repos .gitignore file.
 
 Client
 ======

--- a/teststack.local.toml
+++ b/teststack.local.toml
@@ -1,0 +1,2 @@
+[client]
+name = "docker"

--- a/teststack.toml
+++ b/teststack.toml
@@ -2,7 +2,7 @@
 min_version = 'v0.9.0'
 
 [client]
-name = "docker"
+name = "podman"
 
 [tests.steps]
 env = "env"


### PR DESCRIPTION
teststack.local.toml can be used to overwrite options in the teststack.toml file.